### PR TITLE
changed 'gimp' to generate a more robust AppRun. Tested on Debian 11

### DIFF
--- a/gimp
+++ b/gimp
@@ -47,18 +47,20 @@ cp /opt/$APP/tmp/recipe.yml /opt/$APP/recipe.yml
 ./pkg2appimage ./recipe.yml;
 
 rm -R -f ./$APP/$APP.AppDir/AppRun
-function1="'^Exec=.*'"
-function2="'s|%.||g'"
 echo '#!/bin/sh
 HERE="$(dirname "$(readlink -f "${0}")")"
+#echo "HERE:'\''$HERE'\''"
+cd ${HERE}
 export UNION_PRELOAD="${HERE}"
-LIBS=$($(find . -name "libgimpwidgets*"):$(find . -name "libgimpbase*"):$(find . -name "libgimpcolor*"):$(find . -name "libgimpconfig*"):$(find . -name "libgegl-0*"):$(find . -name "libbabl*"):$(find . -name "libgexiv*"):$(find . -name "libgimpmath*"):$(find . -name "libexiv*"):$(find . -name "libgimpthumb*"):$(find . -name "libgimpmodule*"):$(find . -name "libmypaint*"):$(find . -name "libjson-c*"):$(find . -name "libgimp-2*"):$(find . -name "libgimpui*"))
-for LIBS in ${HERE}/usr/lib/x86_64-linux-gnu/; do
-export LD_PRELOAD=$LIBS
-done
-export PATH=/bin/:/usr/bin/:/usr/local/bin/:/sbin/:"${HERE}"/usr/bin/:"${HERE}"/usr/sbin/:"${HERE}"/usr/games/:"${HERE}"/bin/:"${HERE}"/opt/gimp/:"${HERE}"/sbin/:"${PATH}"
-export LD_LIBRARY_PATH=/lib64/:/usr/lib/:/lib/:/usr/lib/x86_64-linux-gnu/:/lib/x86_64-linux-gnu/"${HERE}"/usr/lib/:"${HERE}"/usr/lib/gimp/:"${HERE}"/usr/lib/i386-linux-gnu/:"${HERE}"/usr/lib/x86_64-linux-gnu/:"${HERE}"/lib/:"${HERE}"/lib/i386-linux-gnu/:"${HERE}"/lib/x86_64-linux-gnu/:"${LD_LIBRARY_PATH}"
-export PKG_CONFIG_PATH="${HERE}"/usr/share/pkgconfig/:$PKG_CONFIG_PATH
+LIBS=:$(find . -type f -name "libgimpwidgets*"):$(find . -type f -name "libgimpbase*"):$(find . -type f -name "libgimpcolor*"):$(find . -type f -name "libgimpconfig*"):$(find . -type f -name "libgegl-0*"):$(find . -type f -name "libbabl*so*"):$(find . -type f -name "libgexiv*"):$(find . -type f -name "libgimpmath*"):$(find . -type f -name "libexiv*"):$(find . -type f -name "libgimpthumb*"):$(find . -type f -name "libgimpmodule*"):$(find . -type f -name "libmypaint*so*"):$(find . -type f -name "libjson-c*"):$(find . -type f -name "libgimp-2*"):$(find . -type f -name "libgimpui*")
+#echo "LIBS:'\''$LIBS'\''"
+export LD_PRELOAD=`echo $LIBS | sed '\''s|:|:'\''${HERE}'\''/|g'\'' | sed '\''s|/\./|/|g'\'' | sed '\''s|^:||g'\''`
+#echo "LD_PRELOAD:'\''$LD_PRELOAD'\''"
+export PATH=/bin:/usr/bin:/usr/local/bin:/sbin:"${HERE}"/usr/bin:"${HERE}"/usr/sbin:"${HERE}"/usr/games:"${HERE}"/bin:"${HERE}"/opt/gimp:"${HERE}"/sbin:"${PATH}"
+#echo "PATH:'\''$PATH'\''"
+export LD_LIBRARY_PATH=/lib64:/usr/lib:/lib:/usr/lib/x86_64-linux-gnu:/lib/x86_64-linux-gnu/"${HERE}"/usr/lib:"${HERE}"/usr/lib/gimp:"${HERE}"/usr/lib/i386-linux-gnu:"${HERE}"/usr/lib/x86_64-linux-gnu:"${HERE}"/lib:"${HERE}"/lib/i386-linux-gnu:"${HERE}"/lib/x86_64-linux-gnu:"${LD_LIBRARY_PATH}"
+#echo "LD_LIBRARY_PATH:'\''$LD_LIBRARY_PATH'\''"
+export PKG_CONFIG_PATH="${HERE}"/usr/share/pkgconfig:$PKG_CONFIG_PATH
 export GIMP2_LOCALEDIR="${HERE}/usr/share/locale"
 export GIMP3_LOCALEDIR="${HERE}/usr/share/locale"
 export GIMP2_DATADIR="${HERE}"/usr/share/gimp/2.0/
@@ -69,8 +71,9 @@ export GIMP3_SYSCONFDIR="${HERE}"/etc/gimp/2.99/
 export GIMP3_PLUGINDIR="${HERE}"/usr/lib/gimp/2.99/
 export GEGL_PATH="${HERE}"/usr/lib/x86_64-linux-gnu/gegl-0.4/
 export BABL_PATH="${HERE}"/usr/lib/x86_64-linux-gnu/babl-0.1/
-EXEC=$(grep -e '$function1' "${HERE}"/*.desktop | head -n 1 | cut -d "=" -f 2- | sed -e '$function2')
-exec ${EXEC} "$@"' >> AppRun
+EXEC=$(grep -e '\''^Exec=.*'\'' "${HERE}"/*.desktop | head -n 1 | cut -d "=" -f 2- | sed -e '\''s| %.||g'\'')
+#echo "EXEC:'\''$EXEC'\''"
+exec ${HERE}/usr/bin/${EXEC} "$@"' >> AppRun
 chmod a+x AppRun
 cp ./AppRun /opt/$APP/
 cp ./AppRun ./$APP/$APP.AppDir/


### PR DESCRIPTION
List of modifications:
- added 'cd ${HERE}' to let run from the desktop menu and find all assets
- removed double LIBS=$($(...)) as it try to execute shared objects
- added '-type f' to find, to avoid find links and directory too
- added 'so*' to libbabl and libmypaint to avoid find two more unneeded files
- removed 'for LIBS in ${HERE}/usr/lib/x86_64-linux-gnu/; do'
  as overwrite LIBS and
  '${HERE}/usr/lib/x86_64-linux-gnu/' is not a list so execute loop only once, do not need a cycle
- use sed in 'export LD_PRELOAD' instead of for loop
- removed trailer '/' in PATH and LD_LIBRARY_PATH definitions
- removed trailer space in EXEC
- use absolute path to run binary to avoid find native distro binary
- added commented debug echo
- removed the two lines:
function1="'^Exec=.*'"
function2="'s|%.||g'"
using escape for single quote inside single quote: `' => '\''`