### PR TITLE
Good news

### DIFF
--- a/.github/workflows/GIMP-DEVELOPER.yml
+++ b/.github/workflows/GIMP-DEVELOPER.yml
@@ -18,7 +18,7 @@ jobs:
       if: always()
       run: |
         sudo apt update
-        sudo apt install libfuse2
+        sudo apt install libfuse2 desktop-file-utils
         wget https://raw.githubusercontent.com/ivan-hc/GIMP-appimage/main/gimp-dev-junest.sh
         chmod a+x ./gimp-dev-junest.sh
         ./gimp-dev-junest.sh

--- a/.github/workflows/GIMP-GIT.yml
+++ b/.github/workflows/GIMP-GIT.yml
@@ -18,7 +18,7 @@ jobs:
       if: always()
       run: |
         sudo apt update
-        sudo apt install libfuse2
+        sudo apt install libfuse2 desktop-file-utils
         wget https://raw.githubusercontent.com/ivan-hc/GIMP-appimage/main/gimp-git-junest.sh
         chmod a+x ./gimp-git-junest.sh
         ./gimp-git-junest.sh

--- a/.github/workflows/GIMP-HYBRID.yml
+++ b/.github/workflows/GIMP-HYBRID.yml
@@ -18,7 +18,7 @@ jobs:
       if: always()
       run: |
         sudo apt update
-        sudo apt install libfuse2
+        sudo apt install libfuse2 desktop-file-utils
         wget https://raw.githubusercontent.com/ivan-hc/GIMP-appimage/main/gimp-hybrid.sh
         chmod a+x ./gimp-hybrid.sh
         ./gimp-hybrid.sh

--- a/.github/workflows/GIMP-STABLE.yml
+++ b/.github/workflows/GIMP-STABLE.yml
@@ -18,7 +18,7 @@ jobs:
       if: always()
       run: |
         sudo apt update
-        sudo apt install libfuse2
+        sudo apt install libfuse2 desktop-file-utils
         wget https://raw.githubusercontent.com/ivan-hc/GIMP-appimage/main/gimp-junest.sh
         chmod a+x ./gimp-junest.sh
         ./gimp-junest.sh

--- a/gimp-dev-junest.sh
+++ b/gimp-dev-junest.sh
@@ -10,7 +10,7 @@ COMPILERS="base-devel"
 
 # CREATE THE APPDIR (DON'T TOUCH THIS)...
 if ! test -f ./appimagetool; then
-	wget -q "$(wget -q https://api.github.com/repos/probonopd/go-appimage/releases -O - | sed 's/"/ /g; s/ /\n/g' | grep -o 'https.*continuous.*tool.*86_64.*mage$')" -O appimagetool
+	wget -q https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage -O appimagetool
 	chmod a+x appimagetool
 fi
 mkdir -p $APP.AppDir
@@ -368,5 +368,5 @@ mkdir -p ./$APP.AppDir/.junest/run/user
 if test -f ./*.AppImage; then
 	rm -R -f ./*archimage*.AppImage
 fi
-ARCH=x86_64 VERSION=$(./appimagetool -v | grep -o '[[:digit:]]*') ./appimagetool -s ./$APP.AppDir
+ARCH=x86_64 ./appimagetool --comp zstd --mksquashfs-opt -Xcompression-level --mksquashfs-opt 20 ./$APP.AppDir
 mv ./*AppImage ./"$(cat ./$APP.AppDir/*.desktop | grep 'Name=' | head -1 | cut -c 6- | sed 's/ /-/g')"_DEV_"$VERSION"-archimage3.4.1-1-x86_64.AppImage

--- a/gimp-git-junest.sh
+++ b/gimp-git-junest.sh
@@ -9,7 +9,7 @@ COMPILERS="base-devel"
 
 # CREATE THE APPDIR (DON'T TOUCH THIS)...
 if ! test -f ./appimagetool; then
-	wget -q "$(wget -q https://api.github.com/repos/probonopd/go-appimage/releases -O - | sed 's/"/ /g; s/ /\n/g' | grep -o 'https.*continuous.*tool.*86_64.*mage$')" -O appimagetool
+	wget -q https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage -O appimagetool
 	chmod a+x appimagetool
 fi
 mkdir -p $APP.AppDir
@@ -367,5 +367,5 @@ mkdir -p ./$APP.AppDir/.junest/run/user
 if test -f ./*.AppImage; then
 	rm -R -f ./*archimage*.AppImage
 fi
-ARCH=x86_64 VERSION=$(./appimagetool -v | grep -o '[[:digit:]]*') ./appimagetool -s ./$APP.AppDir
+ARCH=x86_64 ./appimagetool --comp zstd --mksquashfs-opt -Xcompression-level --mksquashfs-opt 20 ./$APP.AppDir
 mv ./*AppImage ./"$(cat ./$APP.AppDir/*.desktop | grep 'Name=' | head -1 | cut -c 6- | sed 's/ /-/g')"_GIT_"$VERSION"-archimage3.4.1-1-x86_64.AppImage

--- a/gimp-hybrid.sh
+++ b/gimp-hybrid.sh
@@ -9,7 +9,7 @@ BASICSTUFF="binutils debugedit gzip gtk3"
 
 # CREATE THE APPDIR (DON'T TOUCH THIS)...
 if ! test -f ./appimagetool; then
-	wget -q "$(wget -q https://api.github.com/repos/probonopd/go-appimage/releases -O - | sed 's/"/ /g; s/ /\n/g' | grep -o 'https.*continuous.*tool.*86_64.*mage$')" -O appimagetool
+	wget -q https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage -O appimagetool
 	chmod a+x appimagetool
 fi
 mkdir -p $APP.AppDir
@@ -379,5 +379,5 @@ mkdir -p ./$APP.AppDir/.junest/run/user
 if test -f ./*.AppImage; then
 	rm -R -f ./*archimage*.AppImage
 fi
-ARCH=x86_64 VERSION=$(./appimagetool -v | grep -o '[[:digit:]]*') ./appimagetool -s ./$APP.AppDir
+ARCH=x86_64 ./appimagetool --comp zstd --mksquashfs-opt -Xcompression-level --mksquashfs-opt 20 ./$APP.AppDir
 mv ./*AppImage ./"$(cat ./$APP.AppDir/*.desktop | grep 'Name=' | head -1 | cut -c 6- | sed 's/ /-/g')"_"$VERSION"-Hybrid-with-python2-from-Debian-Buster-archimage3.4.1-1-x86_64.AppImage

--- a/gimp-junest.sh
+++ b/gimp-junest.sh
@@ -9,7 +9,7 @@ BASICSTUFF="binutils debugedit gzip gtk3"
 
 # CREATE THE APPDIR (DON'T TOUCH THIS)...
 if ! test -f ./appimagetool; then
-	wget -q "$(wget -q https://api.github.com/repos/probonopd/go-appimage/releases -O - | sed 's/"/ /g; s/ /\n/g' | grep -o 'https.*continuous.*tool.*86_64.*mage$')" -O appimagetool
+	wget -q https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage -O appimagetool
 	chmod a+x appimagetool
 fi
 mkdir -p $APP.AppDir
@@ -366,5 +366,5 @@ mkdir -p ./$APP.AppDir/.junest/run/user
 if test -f ./*.AppImage; then
 	rm -R -f ./*archimage*.AppImage
 fi
-ARCH=x86_64 VERSION=$(./appimagetool -v | grep -o '[[:digit:]]*') ./appimagetool -s ./$APP.AppDir
+ARCH=x86_64 ./appimagetool --comp zstd --mksquashfs-opt -Xcompression-level --mksquashfs-opt 20 ./$APP.AppDir
 mv ./*AppImage ./"$(cat ./$APP.AppDir/*.desktop | grep 'Name=' | head -1 | cut -c 6- | sed 's/ /-/g')"_"$VERSION"-archimage3.4.1-1-x86_64.AppImage


### PR DESCRIPTION
[Appimage/appimagetool](https://github.com/AppImage/appimagetool) now pulls the [static runtime](https://github.com/AppImage/type2-runtime/pull/57) that doesn't depend on fuse2.

This is good because we now can select the compression level, and in the case of gimp it is good for it to be higher.

It also lets you set the output name of the appimage by passing it as an extra argument in the end, I didn't change that though.


